### PR TITLE
Added button to paste address from clipboard + some checks

### DIFF
--- a/app/src/main/java/xyz/tomashrib/zephyruswallet/ui/wallet/WalletNavigation.kt
+++ b/app/src/main/java/xyz/tomashrib/zephyruswallet/ui/wallet/WalletNavigation.kt
@@ -29,7 +29,7 @@ fun WalletNavigation() {
 
         composable(
             route = Screen.SendScreen.route,
-        ) { SendScreen(navController) }
+        ) { SendScreen(navController, LocalContext.current) }
 //
 //        composable(
 //            route = Screen.TransactionsScreen.route,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,4 +22,5 @@
     <string name="recover_wallet">Recover Wallet</string>
     <string name="wallet_syncing">Wallet is Syncing...</string>
     <string name="clear_all">Clear All</string>
+    <string name="paste_address">Paste Address</string>
 </resources>


### PR DESCRIPTION
On the sending screen, there is now added button "Paste Address", which upon click gets the input from the clipboard and pastes it into address input field.

It also has some simple checks

- if input is null
- if input is empty
- if input isn't legacy or segwit or taproot address long in characters

But this definitely needs a proper address validation.

This solves #11 issue.