### PR TITLE
FR: Wallet sync in background, doesnt freeze app

### DIFF
--- a/app/src/main/java/xyz/tomashrib/zephyruswallet/data/Wallet.kt
+++ b/app/src/main/java/xyz/tomashrib/zephyruswallet/data/Wallet.kt
@@ -133,7 +133,7 @@ object Wallet {
 //         }
 //    }
 
-    fun sync(){
+    suspend fun sync(){
         Log.i(TAG, "Wallet is syncing")
         wallet.sync(blockchain, LogProgress)
         Log.i(TAG, "Wallet has synced")


### PR DESCRIPTION
### This PR solves the issue:

- #5 - syncing is now done in the background, it doesn't freeze the UI now